### PR TITLE
Add v2.napochaan.com route to production environment

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -56,6 +56,10 @@ binding = "IMAGES"
 pattern = "napochaan.com"
 custom_domain = true
 
+[[env.production.routes]]
+pattern = "v2.napochaan.com"
+custom_domain = true
+
 [env.production.observability.logs]
 enabled = true
 


### PR DESCRIPTION
## Summary
Added a new custom domain route for `v2.napochaan.com` to the production environment configuration in wrangler.toml.

## Changes
- Added new route configuration for `v2.napochaan.com` with `custom_domain` enabled in the production environment
- This allows the v2 subdomain to be served alongside the existing `napochaan.com` domain on Cloudflare Pages

## Details
The new route follows the same pattern as the existing `napochaan.com` route configuration, enabling traffic to the v2 subdomain to be properly routed and served in the production environment.

https://claude.ai/code/session_01Uxr7HoirWqXzZxwjAQw8Fj